### PR TITLE
Return subtask map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <java.level>8</java.level>
     <jenkins.version>2.222.1</jenkins.version>
     <metrics.version>4.1.6</metrics.version>
-    <revision>4.0.2.9</revision>
+    <revision>4.0.2.11</revision>
     <changelist>-SNAPSHOT</changelist>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <java.level>8</java.level>
     <jenkins.version>2.222.1</jenkins.version>
     <metrics.version>4.1.6</metrics.version>
-    <revision>4.0.2.11</revision>
+    <revision>4.0.2.9</revision>
     <changelist>-SNAPSHOT</changelist>
   </properties>
 

--- a/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
+++ b/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
@@ -161,10 +161,11 @@ public class TimeInQueueAction implements Serializable, RunAction2 {
     }
 
      /**
-     * Returns the total time this {@link Run} spent queuing, including the time spent by subtasks. This is the sum
-     * of {@link #getQueuingDurationMillis()} plus all the {@link SubTaskTimeInQueueAction#getQueuingDurationMillis()}.
+     * Returns the a map of all the subtasks in this {@link Run} mapped to the time spent by each {@link SubTask} in queue.
+     * Subtasks are denoted in the map by chronological order and the subtask time in queue is denoted using
+     * {@link SubTaskTimeInQueueAction#getQueuingDurationMillis()}
      *
-     * @return the total time this {@link Run} spent queuing
+     * @return a map where each {@link SubTask} in this {@link Run} is mapped to each subtask's time in queue
      */
     @Exported(visibility = 2)
     public Map<String, Long> getSubTaskMap() {

--- a/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
+++ b/src/main/java/jenkins/metrics/impl/TimeInQueueAction.java
@@ -30,6 +30,8 @@ import hudson.model.Run;
 import hudson.model.queue.SubTask;
 import java.io.Serializable;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import jenkins.model.RunAction2;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -156,6 +158,27 @@ public class TimeInQueueAction implements Serializable, RunAction2 {
             total += t.getQueuingDurationMillis();
         }
         return total;
+    }
+
+     /**
+     * Returns the total time this {@link Run} spent queuing, including the time spent by subtasks. This is the sum
+     * of {@link #getQueuingDurationMillis()} plus all the {@link SubTaskTimeInQueueAction#getQueuingDurationMillis()}.
+     *
+     * @return the total time this {@link Run} spent queuing
+     */
+    @Exported(visibility = 2)
+    public Map<String, Long> getSubTaskMap() {
+
+        Map<String, Long> subtasks = new HashMap<String, Long>();
+        if (run == null) {
+            return subtasks;
+        }
+        int subtask_count = 0;
+        for (SubTaskTimeInQueueAction t : run.getActions(SubTaskTimeInQueueAction.class)) {
+            subtasks.put("Subtask_" + subtask_count, t.getQueuingDurationMillis());
+            subtask_count = subtask_count + 1;
+        }
+        return subtasks;
     }
 
     /**


### PR DESCRIPTION
Goal: What I set out to accomplish was to be able to publish each job's _subtask_ queue times to _grafana_, using the InfluxDB plugin in order to send that data over. 

A subtask is essentially a chunk of code that a specific executor is tasked to finish. _grafana_ is used to plot data on visual data charts (scatter plots, line graphs, etc).

The metrics plugin handles information in regards to subtask queue time. Turns out InfluxDB uses metrics in order to get these queue times, so I had to modify metrics to send the correct data over to InfluxDB.

My modifications included one function in TimeInQueueAction.java: **getSubTaskMap()**

![Screenshot from 2021-06-24 16-21-02](https://user-images.githubusercontent.com/85509505/123327406-607a1400-d508-11eb-9606-52fc649acdf2.png)


getSubTaskMap() makes a hash map that takes the subtask's relative order and maps it to the subtask queue time. Each subtask is given a number based on the order of when each one first entering the queue. This is the order that is determined by calling **run.getActions(SubTaskTimeInQueueAction.class)**, which returns a list where the subtasks are already in said order. A simple counter variable is used to keep track of the relative order, and is appended to each of the subtask keys as an identifier. Each subtask is then paired with its time in queue and inserted into the hash map. When the function completes, it will return a map of all the subtasks with their queue times.