### PR TITLE
TI-1285-Update changelist so version number is correct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
   <properties>
     <jenkins.version>2.332.1</jenkins.version>
     <revision>4.1.6</revision>
-    <changelist>999999-SNAPSHOT</changelist>
+    <changelist>CUSTOM</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 


### PR DESCRIPTION
Related to associated [influxdb pr](https://github.com/deepfield/influxdb-plugin/pull/7).
Updates the version number so that both influxdb plugin and metrics plugin are matched.